### PR TITLE
Improvents to event handling and APIs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2019 GumGum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here's the full list of options available
 | muted  |true   |false | video will be muted by default  |
 | poster  |null   |false | source for an image to be used as video poster  |
 | preload  |'auto'   |false | standard HTML values for preload (none|metadata|auto)  |
-| look  | false   |false | whether to loop video or not  |
+| loop  | false   |false | whether to loop video or not  |
 | isVAST  | false   |false | enables support for a single VAST / VPAID / MOAT TAG to be parsed and used as source  |
 
 ## Customizing Controls

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This minimal configuration will create a unique video player instance using the 
 
 ## Customization
 
-Here's the full list of options available
+### Options:
 
 |key|defaultValue|required|description|
 |---|---|---|---|
@@ -79,48 +79,59 @@ Here's the full list of options available
 | autoplay  |false   |false | whether to play the video automatically or not  |
 | volume  |1   |false | initial volume for playback must be between 0.0 and 1  |
 | muted  |true   |false | video will be muted by default  |
+| playsinline  | true   |false | [A Boolean attribute indicating that the video is to be played within the element's playback area.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-playsinline) |
 | poster  |null   |false | source for an image to be used as video poster  |
 | preload  |'auto'   |false | standard HTML values for preload (none|metadata|auto)  |
 | loop  | false   |false | whether to loop video or not  |
 | isVAST  | false   |false | enables support for a single VAST / VPAID / MOAT TAG to be parsed and used as source  |
 
-## Customizing Controls
+### Controls
 
 TBD
 
-## APIs
-
-`ggEzVpInstance.play()`: start video playback
-
-`ggEzVpInstance.pause()`: stop video playback
-
-`ggEzVpInstance.playPause()`: toggle pause state on/off
-
-`ggEzVpInstance.volume(floatNum)`: sets the video volume, see volume configuration
-
-`ggEzVpInstance.mute()`: disable video sound
-
-`ggEzVpInstance.unmute()`: enable video sound
-
-`ggEzVpInstance.muteUnmute()`: toggle video sound on/off
-
-`ggEzVpInstance.destroy()`: removes the instance listeners and the DOM element originally attached to
+## Public methods
+|method name|parameters|description|
+|---|---|---|
+|destroy|none|removes all instance and video tag listeners, removes the player from the DOM leaving behind the original container|
+|fullscreenToggle|none|toggles the fullscreen mode|
+|getCurrentTime|none|returns the currentTime from the video tag, this data is also provided by the playback-progress event|
+|muteUnmute|none|toggle video sound on/off|
+|mute|none|disable video sound|
+|on|`eventName, listenerFn`|attaches a listener function to either the video tag or the player instance, the function will be run every time the event is fired, [see events](#events)|
+|once|`eventName, listenerFn`|attaches a listener function to either the video tag or the player instance, the function will fire just on time, [see events](#events)|
+|pause|none|stop video playback|
+|playPause|none|toggle pause state on/off|
+|play|none|start video playback|
+|unmute|none|enable video sound|
+|volume|float number|sets the video volume, [see volume configuration](#customization)|
 
 ## Events
 
-All events emitted from the <video> tag can be listened to by setting a listener on your active player instances:
+Listen for any `<video>` tag [events](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events) or GgEzVp events:
 
 ```
 ggEzVpInstance.on('play', myPlayListener);
+ggEzVpInstance.on('playback-progress', myPlaybackListener);
 ```
 
-The class also emits custom events to extend the behavior:
+Listen to them only once:
 
-|event name|description|
-|---|---|
-|ready| emitted when the class is ready for playback|
-|dataready| emitted when a source for the video is received, either by configuration or VAST parsing|
-|predestroy| emitted before removing listeners and the container node|
+```
+ggEzVpInstance.once('play', myPlayListener);
+ggEzVpInstance.once('playback-progress', myProgressListener);
+```
+
+
+The player also emits custom events to extend the video tag behavior:
+
+|event name|description|payload|
+|---|---|---|
+|data-ready| emitted when a source for the video is received, either by configuration or after asynchronous VAST parsing | `undefined` |
+|playback-progress| emitted when the video currentTime changes | `{ readableTime, duration, currentTime }` |
+|player-click| emitted when clicks are detected inside the container element | click event |
+|pre-destroy| emitted before removing listeners and the container node| `undefined` |
+|ready| emitted when the class is ready for playback| `undefined` |
+|resize| emitted when video tag changes either width or height | `{ width, height }` |
 
 Custom events are provided by [Nano Events](https://github.com/ai/nanoevents)
 

--- a/demo.js
+++ b/demo.js
@@ -10,35 +10,13 @@ window.onload = function onload() {
         autoplay: false
     });
 
-    // VAST test
-    //let playerInstance = new GgEzVp({
-    //    container: 'videoContainer1',
-    //    src:
-    //        'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]',
-    //    autoplay: false,
-    //    isVAST: true
-    //});
-
-    // Configure player
-    const playBtn = document.getElementById('play-btn');
-    playBtn.addEventListener('click', () => playerInstance.playPause());
-
-    const muteBtn = document.getElementById('mute-btn');
-    muteBtn.addEventListener('click', () => playerInstance.muteUnmute());
-
-    const rmBtn = document.getElementById('destroy-btn');
-    rmBtn.addEventListener('click', () => playerInstance.destroy());
-
-    const f5Btn = document.getElementById('reload-btn');
-    f5Btn.addEventListener('click', () => location.reload());
-
     // Set listeners
     playerInstance.on('ready', () => {
         playerInstance.on('play', console.log);
         playerInstance.on('pause', console.log);
         playerInstance.on('timeupdate', console.log);
         playerInstance.on('predestroy', () => {
-            console.log('PRE DESTROY LISTENER');
+            console.log('DESTROYING FIRST CONTAINER');
             playerInstance = null;
         });
     });
@@ -53,28 +31,41 @@ window.onload = function onload() {
         isVAST: true
     });
 
-    // Configure player
-    const playBtn1 = document.getElementById('play-btn1');
-    playBtn1.addEventListener('click', () => playerInstance1.playPause());
-
-    const muteBtn1 = document.getElementById('mute-btn1');
-    muteBtn1.addEventListener('click', () => playerInstance1.muteUnmute());
-
-    const rmBtn1 = document.getElementById('destroy-btn1');
-    rmBtn1.addEventListener('click', () => playerInstance1.destroy());
-
-    const f5Btn1 = document.getElementById('reload-btn1');
-    f5Btn1.addEventListener('click', () => location.reload());
-
     // Set listeners
     playerInstance1.on('ready', () => {
         playerInstance1.on('play', console.log);
         playerInstance1.on('pause', console.log);
         playerInstance1.on('timeupdate', console.log);
         playerInstance1.on('predestroy', () => {
-            console.log('PRE DESTROY LISTENER');
+            console.log('DESTROYING SECOND CONTAINER');
             playerInstance1 = null;
         });
     });
     playerInstance1.on('error', console.log);
 };
+
+// Configure instance 1 buttons
+const playBtn = document.getElementById('play-btn');
+playBtn.addEventListener('click', () => playerInstance.playPause());
+
+const muteBtn = document.getElementById('mute-btn');
+muteBtn.addEventListener('click', () => playerInstance.muteUnmute());
+
+const rmBtn = document.getElementById('destroy-btn');
+rmBtn.addEventListener('click', () => playerInstance.destroy());
+
+const f5Btn = document.getElementById('reload-btn');
+f5Btn.addEventListener('click', () => location.reload());
+
+// Configure instance 2 buttons
+const playBtn1 = document.getElementById('play-btn1');
+playBtn1.addEventListener('click', () => playerInstance1.playPause());
+
+const muteBtn1 = document.getElementById('mute-btn1');
+muteBtn1.addEventListener('click', () => playerInstance1.muteUnmute());
+
+const rmBtn1 = document.getElementById('destroy-btn1');
+rmBtn1.addEventListener('click', () => playerInstance1.destroy());
+
+const f5Btn1 = document.getElementById('reload-btn1');
+f5Btn1.addEventListener('click', () => location.reload());

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,3 +4,45 @@ export const PLAYER_CLICK = 'player-click';
 export const PRE_DESTROY = 'pre-destroy';
 export const READY = 'ready';
 export const RESIZE = 'resize';
+export const DEFAULT_OPTIONS = {
+    container: null,
+    width: null,
+    height: null,
+    src: null,
+    controls: {
+        bg: null,
+        color: '#FFFFFF',
+        play: {
+            color: null,
+            src: null
+        },
+        stop: {
+            color: null,
+            src: null
+        },
+        replay: {
+            color: null,
+            src: null
+        },
+        volume: {
+            color: null,
+            src: null
+        },
+        fullscreen: {
+            color: null,
+            src: null
+        },
+        timer: {
+            color: null
+        }
+    },
+    autoPlay: false,
+    volume: 1,
+    muted: true,
+    poster: null,
+    preload: 'auto',
+    loop: false,
+    isVAST: false,
+    fullscreen: false,
+    playsinline: true
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,3 +3,4 @@ export const READY = 'ready';
 export const PRE_DESTROY = 'pre-destroy';
 export const PLAYBACK_PROGRESS = 'playback-progress';
 export const PLAYER_CLICK = 'player-click';
+export const RESIZE = 'resize';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,6 @@
 export const DATA_READY = 'data-ready';
-export const READY = 'ready';
-export const PRE_DESTROY = 'pre-destroy';
 export const PLAYBACK_PROGRESS = 'playback-progress';
 export const PLAYER_CLICK = 'player-click';
+export const PRE_DESTROY = 'pre-destroy';
+export const READY = 'ready';
 export const RESIZE = 'resize';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,5 @@
+export const DATA_READY = 'data-ready';
+export const READY = 'ready';
+export const PRE_DESTROY = 'pre-destroy';
+export const PLAYBACK_PROGRESS = 'playback-progress';
+export const PLAYER_CLICK = 'player-click';

--- a/src/lib/controls.js
+++ b/src/lib/controls.js
@@ -46,7 +46,8 @@ export default function GgEzControls(playerInstance) {
             pauseIcon.classList.add('active');
         }
         playPause.append(playIcon, pauseIcon);
-        playPause.addEventListener('click', () => {
+        playPause.addEventListener('click', event => {
+            event.stopImmediatePropagation();
             if (playerInstance.player.paused) {
                 pauseIcon.classList.add('active');
                 playIcon.classList.remove('active');
@@ -67,7 +68,8 @@ export default function GgEzControls(playerInstance) {
         const fullscreenIcon = getIcon(controls, iconPaths.fullscreen);
         fullscreen.append(fullscreenIcon);
         // append to correnponding div
-        fullscreen.addEventListener('click', () => {
+        fullscreen.addEventListener('click', event => {
+            event.stopImmediatePropagation();
             playerInstance.fullscreenToggle();
         });
         controlContainer.append(fullscreen);
@@ -84,7 +86,8 @@ export default function GgEzControls(playerInstance) {
         } else {
             volumeIcon.classList.add('active');
         }
-        volume.addEventListener('click', () => {
+        volume.addEventListener('click', event => {
+            event.stopImmediatePropagation();
             if (playerInstance.player.muted) {
                 volumeIcon.classList.add('active');
                 muteIcon.classList.remove('active');

--- a/src/lib/renderVideoElement.js
+++ b/src/lib/renderVideoElement.js
@@ -1,9 +1,22 @@
-export default function renderVideoElement(playerInstance) {
+export default function renderVideoElement() {
     const {
+        player,
         container,
         VASTData,
-        config: { src, isVAST, width, height, autoplay, volume, muted, poster, preload, loop }
-    } = playerInstance;
+        config: {
+            src,
+            isVAST,
+            width,
+            height,
+            autoplay,
+            volume,
+            muted,
+            poster,
+            preload,
+            loop,
+            playsinline
+        }
+    } = this;
 
     // Group all the video element attributes
     const attrsConfig = {
@@ -13,7 +26,9 @@ export default function renderVideoElement(playerInstance) {
         autoplay,
         poster,
         preload,
-        loop
+        loop,
+        playsinline,
+        'webkit-playsinline': playsinline
     };
 
     // Validate that there is a source
@@ -47,15 +62,12 @@ export default function renderVideoElement(playerInstance) {
     // Find the sources for media playback
     const sources = VASTSources || (typeof src === 'string' ? [src] : src);
 
-    // Create the video node
-    const video = document.createElement('video');
-
     // Set the default muted value
-    video.muted = muted;
+    player.muted = muted;
 
     // Add all attributes to the video node
     attributes.forEach(([key, value]) => {
-        video.setAttribute(key, isBooleanAttr(key) ? key : value);
+        player.setAttribute(key, isBooleanAttr(key) ? '' : value);
     });
 
     // Add all sources to the video node
@@ -64,14 +76,12 @@ export default function renderVideoElement(playerInstance) {
         source.src = s;
         // TODO: need a better way to set type
         source.type = `video/${s.split('.').reverse()[0]}`;
-        video.appendChild(source);
+        console.log({ source });
+        player.appendChild(source);
     });
 
     // Insert the video node
-    container.appendChild(video);
-
-    // Return the video container to the class
-    return video;
+    container.appendChild(player);
 }
 
-const isBooleanAttr = k => ['autoplay', 'loop'].includes(k);
+const isBooleanAttr = k => ['autoplay', 'loop', 'playsinline', 'webkit-playsinline'].includes(k);

--- a/src/main.js
+++ b/src/main.js
@@ -37,10 +37,10 @@ export default class GgEzVp {
         const { container: containerId, isVAST } = this.config;
         const currentContainer = document.getElementById(containerId);
         if (!currentContainer) {
-            throw new Error('No container found. Is the id correct?');
+            throw new Error(`No container found. Is the id correct? (${containerId})`);
         }
         currentContainer.classList.add('gg-ez-container');
-        console.log({ currentContainer });
+        console.log({ containerId });
         this.container = currentContainer;
         //console.log({ parseAdXML });
         this.renderVideoElement();
@@ -90,17 +90,24 @@ export default class GgEzVp {
 
         // Set player event listeners
         if (this.player && (!isInternal || eventName === 'error')) {
+            console.log('player event');
+            console.log({ eventName, args });
             this.player.addEventListener(eventName, ...args);
             // Store listener for teardown on this.destroy
             this.playerListeners.push([eventName, ...args]);
         }
     };
 
+    // Listen for an event just once
     once(event, callback) {
+        console.log({ event, callback });
+        // TODO: should "once" events be pushed to this.instanceListeners?
         const unbind = this.emitter.on(event, function(...args) {
             unbind();
+            console.log({ unbind, args });
             callback.apply(this, args);
         });
+        console.log({ unbind });
         return unbind;
     }
 
@@ -197,7 +204,7 @@ export default class GgEzVp {
         this.emitter.emit('predestroy');
         this.pause();
         this.removeListeners();
-        this.container.parentNode.removeChild(this.container);
+        this.container.innerHTML = '';
     };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ import {
 } from './constants';
 
 // List of events fired by the instance instead of events the <video> tag
-const internalEvents = [DATA_READY, PLAYBACK_PROGRESS, PRE_DESTROY, READY, RESIZE];
+const internalEvents = [DATA_READY, PLAYBACK_PROGRESS, PLAYER_CLICK, PRE_DESTROY, READY, RESIZE];
 
 export default class GgEzVp {
     constructor(options) {
@@ -43,10 +43,10 @@ export default class GgEzVp {
         // set vast data default
         this.VASTData = null;
         // set up any extra processes
-        this.init();
+        this.__init();
     }
 
-    init = () => {
+    __init = () => {
         const { container: containerId, isVAST } = this.config;
         const currentContainer = document.getElementById(containerId);
         if (!currentContainer) {
@@ -54,23 +54,23 @@ export default class GgEzVp {
         }
         currentContainer.classList.add('gg-ez-container');
         // set click listener on player
-        this.nodeOn(currentContainer, 'click', this.emitPlayerClick);
+        this.__nodeOn(currentContainer, 'click', this.__emitPlayerClick);
         // listen for <video> tag resize
-        this.nodeOn(window, RESIZE, this.playerResizeListener());
+        this.__nodeOn(window, RESIZE, this.__playerResizeListener());
         this.container = currentContainer;
-        this.renderVideoElement(isVAST);
+        this.__renderVideoElement(isVAST);
         if (isVAST) {
-            return this.fetchVASTData();
+            return this.__fetchVASTData();
         }
     };
 
-    mountVideoElement = mountVideoElement;
+    __mountVideoElement = mountVideoElement;
 
     // Renders the video element once the data to render it is ready
-    renderVideoElement = isVAST => {
+    __renderVideoElement = isVAST => {
         const renderer = () => {
             const { controls } = this.config;
-            this.mountVideoElement();
+            this.__mountVideoElement();
             this.controlContainer = controls ? videoControls(this) : null;
             if (this.controlContainer)
                 this.container.addEventListener('mouseenter', () =>
@@ -80,7 +80,7 @@ export default class GgEzVp {
                 this.controlContainer.classList.remove('active')
             );
             // set up playback progress listener
-            this.on('timeupdate', this.playbackProgressReporter);
+            this.on('timeupdate', this.__playbackProgressReporter);
             this.ready = true;
             const callback = () => this.emitter.emit(READY);
             if (requestAnimationFrame) {
@@ -96,7 +96,7 @@ export default class GgEzVp {
     };
 
     // helps retrieve and parse the VAST data
-    fetchVASTData = async () => {
+    __fetchVASTData = async () => {
         try {
             this.VASTData = await parseAdXML(this);
             this.emitter.emit(DATA_READY);
@@ -105,22 +105,73 @@ export default class GgEzVp {
         }
     };
 
-    storedListeners = {
-        on: [],
-        once: []
+    __isInternalEvent = eventName => internalEvents.includes(eventName);
+
+    __nodeOn = (node, eventName, ...args) => {
+        node.addEventListener(eventName, ...args);
+        // Store listener for teardown on this.destroy
+        const eventData = [node, eventName, ...args];
+        this.__nodeListeners.push(eventData);
+        // return the node teardown function
+        return () => {
+            this.__nodeListeners = this.__nodeListeners.filter(data => data !== eventData);
+            node.removeEventListener(eventName, ...args);
+        };
     };
 
-    isInternalEvent = eventName => internalEvents.includes(eventName);
+    __nodeListeners = [];
+
+    __emitPlayerClick = (...args) => {
+        this.emitter.emit(PLAYER_CLICK, ...args);
+    };
+
+    __playerResizeListener = () => {
+        const { offsetWidth: initialWidth, offsetHeight: initialHeight } = this.player;
+        this.dimensions.width = initialWidth;
+        this.dimensions.height = initialHeight;
+        return this.__resizeHandler;
+    };
+
+    __resizeHandler = () => {
+        const { offsetWidth: currentWidth, offsetHeight: currentHeight } = this.player;
+        const changedWidth = currentWidth !== this.dimensions.width;
+        const changedHeight = currentHeight !== this.dimensions.height;
+        if (changedWidth || changedHeight) {
+            const newDimensions = { width: currentWidth, height: currentHeight };
+            this.dimensions = newDimensions;
+            this.emitter.emit(RESIZE, newDimensions);
+        }
+    };
+
+    // Listens for timeupdate and emits an event with duration, currentTime and readableTime
+    __playbackProgressReporter = () => {
+        const { currentTime, duration } = this.player;
+        const mins = Math.floor(currentTime / 60);
+        const secs = Math.floor(currentTime % 60);
+        const readableTime = `${mins}:${secs < 10 ? `0${secs}` : secs}`;
+        this.emitter.emit(PLAYBACK_PROGRESS, { readableTime, duration, currentTime });
+    };
+
+    // Teardown methods
+    __removeListeners = () => {
+        // remove internal listeners
+        unbindAll(this.emitter);
+
+        // remove player listeners
+        this.__nodeListeners.forEach(([node, ...args]) => {
+            node.removeEventListener(...args);
+        });
+    };
 
     // event handler
     on = (eventName, ...args) => {
-        const isInternal = this.isInternalEvent(eventName);
+        const isInternal = this.__isInternalEvent(eventName);
 
         const teardown = isInternal
             ? // Set instance listener
               this.emitter.on.apply(this.emitter, [eventName, ...args])
             : // Set player listeners
-              this.nodeOn(this.player, eventName, ...args);
+              this.__nodeOn(this.player, eventName, ...args);
 
         // return the teardown function
         return teardown;
@@ -136,45 +187,9 @@ export default class GgEzVp {
         return unbind;
     };
 
-    nodeOn = (node, eventName, ...args) => {
-        node.addEventListener(eventName, ...args);
-        // Store listener for teardown on this.destroy
-        const eventData = [node, eventName, ...args];
-        this.nodeListeners.push(eventData);
-        // return the node teardown function
-        return () => {
-            this.nodeListeners = this.nodeListeners.filter(data => data !== eventData);
-            node.removeEventListener(eventName, ...args);
-        };
-    };
-
-    nodeListeners = [];
-
-    emitPlayerClick = (...args) => {
-        this.emitter.emit(PLAYER_CLICK, ...args);
-    };
-
     dimensions = {
         width: 0,
         height: 0
-    };
-
-    playerResizeListener = () => {
-        const { offsetWidth: initialWidth, offsetHeight: initialHeight } = this.player;
-        this.dimensions.width = initialWidth;
-        this.dimensions.height = initialHeight;
-        return this.resizeHandler;
-    };
-
-    resizeHandler = () => {
-        const { offsetWidth: currentWidth, offsetHeight: currentHeight } = this.player;
-        const changedWidth = currentWidth !== this.dimensions.width;
-        const changedHeight = currentHeight !== this.dimensions.height;
-        if (changedWidth || changedHeight) {
-            const newDimensions = { width: currentWidth, height: currentHeight };
-            this.dimensions = newDimensions;
-            this.emitter.emit(RESIZE, newDimensions);
-        }
     };
 
     play = () => {
@@ -249,30 +264,10 @@ export default class GgEzVp {
         }
     };
 
-    // Listens for timeupdate and emits an event with duration, currentTime and readableTime
-    playbackProgressReporter = () => {
-        const { currentTime, duration } = this.player;
-        const mins = Math.floor(currentTime / 60);
-        const secs = Math.floor(currentTime % 60);
-        const readableTime = `${mins}:${secs < 10 ? `0${secs}` : secs}`;
-        this.emitter.emit(PLAYBACK_PROGRESS, { readableTime, duration, currentTime });
-    };
-
-    // Teardown methods
-    removeListeners = () => {
-        // remove internal listeners
-        unbindAll(this.emitter);
-
-        // remove player listeners
-        this.nodeListeners.forEach(([node, ...args]) => {
-            node.removeEventListener(...args);
-        });
-    };
-
     destroy = () => {
         this.emitter.emit(PRE_DESTROY);
         this.pause();
-        this.removeListeners();
+        this.__removeListeners();
         this.container.innerHTML = '';
     };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,7 @@ export default class GgEzVp {
 
     __isInternalEvent = eventName => internalEvents.includes(eventName);
 
+    // add event listeners to any node
     __nodeOn = (node, eventName, ...args) => {
         node.addEventListener(eventName, ...args);
         // Store listener for teardown on this.destroy
@@ -119,10 +120,12 @@ export default class GgEzVp {
         };
     };
 
+    // list of active node event listeners
     __nodeListeners = [];
 
-    __emitPlayerClick = (...args) => {
-        this.emitter.emit(PLAYER_CLICK, ...args);
+    __emitPlayerClick = event => {
+        const target = this.controlContainer;
+        this.emitter.emit(PLAYER_CLICK, event);
     };
 
     __playerResizeListener = () => {

--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,7 @@ export default class GgEzVp {
         if (!currentContainer) {
             throw new Error('No container found. Is the id correct?');
         }
-        currentContainer.className += ' gg-ez-container';
+        currentContainer.classList.add('gg-ez-container');
         console.log({ currentContainer });
         this.container = currentContainer;
         //console.log({ parseAdXML });
@@ -96,6 +96,14 @@ export default class GgEzVp {
         }
     };
 
+    once(event, callback) {
+        const unbind = this.emitter.on(event, function(...args) {
+            unbind();
+            callback.apply(this, args);
+        });
+        return unbind;
+    }
+
     instanceListeners = [];
 
     playerListeners = [];
@@ -118,7 +126,7 @@ export default class GgEzVp {
     };
 
     volume = val => {
-        const value = val < 0 ? 0 : val > 1 ? 1 : value;
+        const value = val < 0 ? 0 : val > 1 ? 1 : val;
         this.player.volume = value;
     };
 
@@ -201,7 +209,6 @@ const defaultOptions = {
     controls: {
         bg: null,
         color: '#FFFFFF',
-        timer: true,
         play: {
             color: null,
             src: null

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,7 @@ import mountVideoElement from './lib/renderVideoElement';
 import parseAdXML from './lib/parseAdXML';
 import videoControls from './lib/controls';
 
-const DATA_READY = 'data-ready';
-const READY = 'ready';
-const PRE_DESTROY = 'pre-destroy';
-const PLAYBACK_PROGRESS = 'playback-progress';
-const PLAYER_CLICK = 'player-click';
+import { DATA_READY, READY, PRE_DESTROY, PLAYBACK_PROGRESS, PLAYER_CLICK } from './constants';
 
 const internalEvents = [READY, DATA_READY, PRE_DESTROY, PLAYBACK_PROGRESS];
 
@@ -123,10 +119,7 @@ export default class GgEzVp {
             : // Set player listeners
               this.nodeOn(this.player, eventName, ...args);
 
-        console.log({ teardown });
-
         // return the teardown function
-        console.log(this.nodeListeners);
         return teardown;
     };
 
@@ -149,7 +142,6 @@ export default class GgEzVp {
         return () => {
             this.nodeListeners = this.nodeListeners.filter(data => data !== eventData);
             node.removeEventListener(eventName, ...args);
-            console.log(this.nodeListeners);
         };
     };
 
@@ -236,9 +228,6 @@ export default class GgEzVp {
         this.nodeListeners.forEach(([node, ...args]) => {
             node.removeEventListener(...args);
         });
-
-        //this.nodeListeners = [];
-        console.log(this.nodeListeners);
     };
 
     destroy = () => {

--- a/src/main.js
+++ b/src/main.js
@@ -59,14 +59,6 @@ export default class GgEzVp {
 
     mountVideoElement = mountVideoElement;
 
-    play = () => {
-        this.player.play();
-    };
-
-    pause = () => {
-        this.player.pause();
-    };
-
     // Renders the video element once the data to render it is ready
     renderVideoElement = isVAST => {
         const renderer = () => {
@@ -151,6 +143,14 @@ export default class GgEzVp {
         this.emitter.emit(PLAYER_CLICK, ...args);
     };
 
+    play = () => {
+        this.player.play();
+    };
+
+    pause = () => {
+        this.player.pause();
+    };
+
     // Playback methods
     playPause = () => {
         if (this.player.paused) {
@@ -177,6 +177,11 @@ export default class GgEzVp {
 
     unmute = () => {
         this.player.muted = false;
+    };
+
+    getCurrentTime = () => {
+        const { currentTime } = this.player;
+        return currentTime;
     };
 
     fullscreenToggle = () => {

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
     background: rebeccapurple;
     margin: 0 auto;
 }
+
 video {
     width: 100%;
 }


### PR DESCRIPTION
This PR adds a few features:

- add `once` listener to fire listeners once
- refactor `on` method to always return a teardown function and keep track of all active node listeners
- creation of `<video>` tag in constructor to allow early event listening
- improved `destroy` method now keeps the container and removes all instance and node listeners
- custom events: `playback-progress, player-click, resize`. See README.md for details.
- support playsinline attribute by default
- prevent control clicks from propagating
- MIT license added
- general code tiding

BTW, reviewers, you don't really have to review this PR, I just wanted to keep you updated!