### PR TITLE
Bugfix/hide empty control sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ See the Styles section for information on how to customize the visuals.
 |---|---|---|
 |timestamp|true|display the current time of the video in the format [m:ss]|
 |volume|true|display the volume controls (mute toggle and range input)|
+|volumeRange|true|the volume range input can be hidden if only the volume button is needed|
 |progress|true|display the playback progress bar, clicking on the bar will set the video currentTime to the selected percentage (except on Ads)|
 |play|true|show the play/pause button|
 |expand|true|show the expand to fullscreen button|
@@ -229,7 +230,9 @@ There are also a few modifier selectors applied to the container `.gg-ez-vp`:
 |---|---|
 |.gg-ez-vp--no-scrub| applied on `isVAST: true` or `isAd: true`. Prevents displaying the scrub and adjusts ad styles.|
 |.gg-ez-vp--skip| applied when the skip button will be displayed|
-|.gg-ez-vp--volume-only| adjusts the styles when only the volume button is displayed for better distribution|
+|.gg-ez-vp--volume-only| adjusts the styles when only the volume toggle button is displayed|
+
+See src/styles.css for all styles.
 
 
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -13,6 +13,7 @@ export const VPAID_STARTED = 'VPAID-started';
 export const TIMESTAMP_AD = 'timestampAd';
 export const SKIP = 'skip';
 export const VOLUME = 'volume';
+export const VOLUME_RANGE = `${VOLUME}Range`;
 export const PROGRESS = 'progress';
 export const TIMESTAMP = 'timestamp';
 export const PLAY = 'play';
@@ -22,6 +23,7 @@ const controls = {
     [TIMESTAMP_AD]: false,
     [SKIP]: false,
     [VOLUME]: true,
+    [VOLUME_RANGE]: true,
     [PROGRESS]: true,
     [TIMESTAMP]: true,
     [PLAY]: true,

--- a/src/styles.css
+++ b/src/styles.css
@@ -386,20 +386,22 @@ div.gg-ez-vp--progress-filled:hover::after {
 /* Add class gg-ez-vp--volume-only */
 /* Example: <div class="gg-ez-vp  gg-ez-vp--volume-only"> */
 
-.gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--top > .gg-ez-vp--item-left {
-    display: inherit;
-}
-
 .gg-ez-vp--volume-only .gg-ez-vp--controls {
     position: absolute;
     left: 20px;
     bottom: 20px;
-    height: 70px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
+    width: 30px;
+    height: auto;
     transform: translateY(0);
     transition: all .3s;
+}
+
+.gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--bottom,
+.gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--bottom,
+.gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--volume,
+.gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--bottom > .gg-ez-vp--item-left {
+    display: inline-block;
+    width: auto;
 }
 
 .gg-ez-vp--volume-only.gg-ez-vp--no-scrub .gg-ez-vp--controls {


### PR DESCRIPTION
Includes additional styles for `gg-ez-vp--volume-only` selector and a `volumeRange` control option to disable the range individually.

Closes #27, #28 