### PR TITLE
preload volume/play state icons

### DIFF
--- a/src/helpers/preloadIcons.js
+++ b/src/helpers/preloadIcons.js
@@ -1,0 +1,6 @@
+export default function preloadIcons(iconsList, base = '.') {
+    iconsList?.forEach(iconName => {
+        const img = new Image();
+        img.src = `${base}/icons/${iconName}.svg`;
+    });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ import {
     DEFAULT_OPTIONS as defaultOptions
 } from './constants';
 
+const JS_FILENAME = `/${CSS_ROOT}.js`;
+
 // List of events fired by the instance instead of events the <video> tag
 const internalEvents = [
     DATA_READY,
@@ -60,6 +62,8 @@ export default class GgEzVp {
         // set vast data default
         this.VASTData = null;
         this.VPAIDWrapper = null;
+        // find the base URL that the file was loaded from
+        this.__baseURL = this.__getBaseURL();
         // set up any extra processes
         this.__init();
     }
@@ -96,6 +100,18 @@ export default class GgEzVp {
         config.volume = parseFloat(config.volume);
         this.__prevVol = config.volume;
         return config;
+    };
+
+    // find the base URL that the file was loaded from
+    // only one URL ending in '/gg-ez-vp.js' is allowed
+    __getBaseURL = () => {
+        const ggEzVpScripts = [].slice
+            .call(document.getElementsByTagName('script'))
+            .filter(a => a.src.includes(JS_FILENAME));
+        if (ggEzVpScripts.length > 1) {
+            throw Error(`GgEzVp [Error]: loading more than one ${JS_FILENAME}`);
+        }
+        return ggEzVpScripts[0].src.replace(JS_FILENAME, '');
     };
 
     // set up controls and internal listeners

--- a/src/lib/controls/play.js
+++ b/src/lib/controls/play.js
@@ -1,4 +1,5 @@
 import createNode from '../../helpers/createNode';
+import preloadIcons from '../../helpers/preloadIcons';
 import { PLAY } from '../../constants';
 const PAUSE = 'pause';
 const REPLAY = 'replay';
@@ -7,6 +8,9 @@ export default function play(container) {
     const button = createNode('button', [this.__getCSSClass('button-icon'), PLAY], {
         type: 'button'
     });
+    const inactiveIcons = [REPLAY, PAUSE];
+
+    preloadIcons(inactiveIcons, this.__baseURL);
 
     this.__nodeOn(button, 'click', e => {
         e.stopPropagation?.();
@@ -14,7 +18,7 @@ export default function play(container) {
     });
 
     this.on(PLAY, listenerCreator(button, [REPLAY, PLAY], PAUSE));
-    this.on(PAUSE, listenerCreator(button, [REPLAY, PAUSE], PLAY));
+    this.on(PAUSE, listenerCreator(button, inactiveIcons, PLAY));
     this.on('ended', listenerCreator(button, [PLAY, PAUSE], REPLAY));
 
     container.appendChild(button);

--- a/src/lib/controls/volume.js
+++ b/src/lib/controls/volume.js
@@ -1,9 +1,15 @@
 import { VOLUME } from '../../constants';
 import createNode from '../../helpers/createNode';
+import preloadIcons from '../../helpers/preloadIcons';
 
 /* note: for initial volume, see applyConfigToVideoElement */
 
 const MUTE = 'mute';
+const LOW = 'low';
+const MEDIUM = 'medium';
+const HIGH = 'high';
+
+const intensities = [MUTE, LOW, MEDIUM, HIGH];
 
 export default function volume(container) {
     const {
@@ -38,6 +44,14 @@ export default function volume(container) {
     };
 
     const initialIntensity = getVolumeIntensity(initialVolume, initialMuted);
+    const iconsToLoad = intensities
+        .filter(i => i !== initialIntensity)
+        .map(i => {
+            if (i === MUTE) return i;
+            if (i === MEDIUM) i = 'med';
+            return `${i}-volume`;
+        });
+    preloadIcons(iconsToLoad, this.__baseURL);
 
     button = createNode('button', [this.__getCSSClass('button-icon'), initialIntensity], {
         type: 'button'
@@ -86,7 +100,7 @@ const inputAttrs = {
 const getVolumeIntensity = (currentVolume, muted) => {
     const volume = parseFloat(currentVolume);
     if (muted || volume === 0) return MUTE;
-    if (volume <= 0.33) return 'low';
-    if (volume > 0.33 && volume < 0.66) return 'medium';
-    return 'high';
+    if (volume <= 0.33) return LOW;
+    if (volume > 0.33 && volume < 0.66) return MEDIUM;
+    return HIGH;
 };


### PR DESCRIPTION
This PR will preload icons for inactive states for play and volume buttons.
Doing this required filtering out the script tags in the DOM, which will have repercussions on the ESM and CJS bundles, which we will have to address later.