### PR TITLE
Feature/optional ad controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This minimal configuration will create a unique video player instance using the 
 | preload  |'auto'   |false | standard HTML values for preload (none|metadata|auto)  |
 | loop  | false   |false | whether to loop video or not  |
 | isVAST  | false   |false | enables support for a single VAST / VPAID / MOAT TAG to be parsed and used as source, will force displaying the ad controls  |
-| isAd  | false   |false | forces displaying the ad controls instead of the regular contols  |
+| adControls  | false   |false | forces displaying the ad controls instead of the regular contols  |
 
 ### Controls
 Besides the programmatic interaction with the player, there are also a number of controls displayed by default, they can be toggled by passing a `controls` property in the initial configuration.
@@ -130,7 +130,7 @@ See the Styles section for information on how to customize the visuals.
 |skip|false|**used only for Ads**, will display a skip button|
 
 
-Additionally, passing the `isVAST: true` or `isAd: true` options, will display a different set of controls for Ads:
+Additionally, passing the `isVAST: true` or `adControls: true` options, will display a different set of controls for Ads:
 
 ![Ad Controls](./images/ad_controls.png)
 
@@ -142,7 +142,7 @@ Additionally, passing the `isVAST: true` or `isAd: true` options, will display a
 |play|true|show the play/pause button|
 |expand|true|show the expand to fullscreen button|
 
- **Note:** the `timestamp` control will be disabled when either `isVAST` or `isAd` are true and instead `timestampAd` will be displayed.
+ **Note:** the `timestamp` control will be disabled when either `isVAST` or `adControls` are true and instead `timestampAd` will be displayed.
 
 #### Control configuration examples
 ```
@@ -167,7 +167,7 @@ const customControls = {
 const customControls = {
     container: 'myVideo',
     src: 'myvideo.mp4',
-    isAd: true, // using isVAST will also enable ad controls
+    adControls: true, // using isVAST will also enable ad controls
     controls: {
         timestampAd: false,
         expand: false,
@@ -231,7 +231,7 @@ There are also a few modifier selectors applied to the container `.gg-ez-vp`:
 
 |selector|description|
 |---|---|
-|.gg-ez-vp--no-scrub| applied on `isVAST: true` or `isAd: true`. Prevents displaying the scrub and adjusts ad styles.|
+|.gg-ez-vp--no-scrub| applied on `adControls: true`. Prevents displaying the scrub and adjusts ad styles.|
 |.gg-ez-vp--skip| applied when the skip button will be displayed|
 |.gg-ez-vp--volume-only| adjusts the styles when only the volume toggle button is displayed|
 |.gg-ez-vp--touchscreen| added when the device uses a touchscreen, this will show all enabled controls instead of activating them on hover  |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the Styles section for information on how to customize the visuals.
 |skip|false|**used only for Ads**, will display a skip button|
 
 
-Additionally, passing the `isVAST: true` or `adControls: true` options, will display a different set of controls for Ads:
+Additionally, passing the `adControls: true` option, will display a different set of controls for Ads:
 
 ![Ad Controls](./images/ad_controls.png)
 
@@ -142,7 +142,7 @@ Additionally, passing the `isVAST: true` or `adControls: true` options, will dis
 |play|true|show the play/pause button|
 |expand|true|show the expand to fullscreen button|
 
- **Note:** the `timestamp` control will be disabled when either `isVAST` or `adControls` are true and instead `timestampAd` will be displayed.
+ **Note:** the `timestamp` control will be disabled when `adControls` is true and instead `timestampAd` will be displayed.
 
 #### Control configuration examples
 ```
@@ -167,7 +167,7 @@ const customControls = {
 const customControls = {
     container: 'myVideo',
     src: 'myvideo.mp4',
-    adControls: true, // using isVAST will also enable ad controls
+    adControls: true, // will enable ad controls
     controls: {
         timestampAd: false,
         expand: false,

--- a/demo.js
+++ b/demo.js
@@ -9,7 +9,7 @@ window.onload = function onload() {
         src: 'https://aba.gumgum.com/13861/8/big_buck_bunny_640x360.mp4',
         autoplay: false,
         volume: '0.5',
-        isAd: true
+        adControls: true
     });
 
     // Set listeners

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -41,7 +41,7 @@ export const DEFAULT_OPTIONS = {
     poster: null,
     preload: 'auto',
     loop: false,
-    isAd: false,
+    adControls: false,
     isVAST: false,
     fullscreen: false,
     playsinline: true,

--- a/src/index.js
+++ b/src/index.js
@@ -72,9 +72,7 @@ export default class GgEzVp {
     }
 
     __getConfig = options => {
-        const isAd = options?.isAd || options?.isVAST;
-
-        const adControlOpts = isAd
+        const adControlOpts = options?.adControls
             ? {
                   [TIMESTAMP_AD]: options.controls?.[TIMESTAMP_AD] ?? true,
                   [SKIP]: options.controls?.[SKIP] ?? true,

--- a/src/lib/controls/index.js
+++ b/src/lib/controls/index.js
@@ -11,7 +11,7 @@ import play from './play';
 export default function renderControls() {
     const { container, config, __onTouchScreen } = this;
     if (!config.controls) return;
-    const isAd = config.isAd || config.isVAST;
+    const isAd = config.adControls;
     const controls = document.createElement('div');
     if (isAd) container.classList.add(this.__getCSSClass('no-scrub'));
     if (__onTouchScreen) container.classList.add(this.__getCSSClass('touchscreen'));
@@ -21,10 +21,10 @@ export default function renderControls() {
 }
 
 function nodeRenderer(config, sections, container) {
-    const { isVAST, controls, isAd } = config;
+    const { controls, adControls } = config;
     sections.forEach(node => {
         const { name, tagType, children, component } = node;
-        const isAllowed = shouldNodeRender(node, isAd || isVAST, controls);
+        const isAllowed = shouldNodeRender(node, adControls, controls);
         if (!isAllowed) return;
         if (tagType) {
             const node = document.createElement(tagType);

--- a/src/lib/controls/progress.js
+++ b/src/lib/controls/progress.js
@@ -6,7 +6,6 @@ export default function progress(container) {
     const progressContainer = createNode('div', classNameRoot);
     const progressBar = createNode('div', `${classNameRoot}-bar`);
     const progressFill = createNode('div', `${classNameRoot}-filled`);
-    const isAd = this.config.isAd || this.config.isVAST;
     let mouseOverBar = false;
 
     this.on(PLAYBACK_PROGRESS, ({ currentTime, duration }) => {
@@ -17,7 +16,7 @@ export default function progress(container) {
         }
     });
 
-    if (!isAd) {
+    if (!this.config.adControls) {
         this.__nodeOn(progressBar, 'click', e => {
             e.stopPropagation?.();
             const duration = this.getDuration();


### PR DESCRIPTION
This will make the ad controls optional by setting the `adControls: true` option.
VAST sources won't show ad controls by default.

Closes #41 