### PR TITLE
Bugfix/mobile autoplay electric boogaloo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -38,7 +38,9 @@
                 </div>
             </div>
         </div>
-        <script src="dist/gg-ez-vp.js" async ></script>
+
+        <script src="https://c.gumgum.com/vp/latest/gg-ez-vp.js" async ></script>
+        <!-- local URL <script src="dist/gg-ez-vp.js" async ></script> -->
         <script src="demo.js" async ></script>
     </body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -38,7 +38,7 @@
                 </div>
             </div>
         </div>
-        <script src="https://c.gumgum.com/vp/latest/gg-ez-vp.js" async ></script>
+        <script src="dist/gg-ez-vp.js" async ></script>
         <script src="demo.js" async ></script>
     </body>
 </html>

--- a/src/helpers/applyConfigToVideoElement.js
+++ b/src/helpers/applyConfigToVideoElement.js
@@ -6,7 +6,7 @@ export default function applyConfigToVideoElement({
     VASTSources,
     setVolume
 }) {
-    setVolume(muted ? 0 : volume);
+    setVolume(muted || !volume ? 0 : volume);
     appendVideoAttributes(configAttributes, player);
     if (isVPAID) return;
     appendVideoSources(src, player, VASTSources);

--- a/src/index.js
+++ b/src/index.js
@@ -180,16 +180,14 @@ export default class GgEzVp {
         if (this.isVPAID) {
             return this.__setReadyNextTick();
         }
-        this.once('canplay', this.__setReadyNextTick);
+        this.once('loadedmetadata', this.__setReadyNextTick);
     };
 
     __setReadyNextTick = () => {
+        const nextTick = requestAnimationFrame || setTimeout;
         // Execute the callback in the next cycle, using requestAnimationFrame
         // if available or setTimeout as a fallback
-        if (window.requestAnimationFrame) {
-            return requestAnimationFrame(this.__setReady);
-        }
-        setTimeout(this.__setReady);
+        nextTick(this.__setReady);
     };
 
     __setReady = () => {
@@ -409,6 +407,7 @@ export default class GgEzVp {
             return VPAIDWrapper.setAdVolume(volume);
         }
         this.player.volume = volume;
+        this.player.muted = !volume;
     };
 
     // mute audio


### PR DESCRIPTION
This PR fixes autoplay issues in the mobile versions of Firefox, Safari and Edge.

The first fix for Safari was to change the `canplay` event for the `loadedmetadata`, as the first one is not supported by Safari, but is supported by every other browser.

The second fix that was required for all the mentioned browsers is to not just set the volume to 0, but also either add the `muted` attribute to the video element, or to set it with `video.muted = true` (and also removing it when changing the volume). This is because autoplay is only allowed when videos are muted, setting the volume to 0 mutes the video in chrome, but in other browsers it must be manually set so that the autoplay is allowed. Otherwise, Safari would throw an error:

```
Unhandled Promise Rejection: NotAllowedError
```