### PR TITLE
Set volume icons and mute toggle based on muted property

### DIFF
--- a/src/helpers/applyConfigToVideoElement.js
+++ b/src/helpers/applyConfigToVideoElement.js
@@ -1,3 +1,9 @@
+/* Note: volume can only be set by the user in Safari Mobile.
+ * this.player.volume is read-only and will always return 1.
+ * https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html
+ * On other browsers, the muted configuration will take precedence over volume.
+ */
+
 export default function applyConfigToVideoElement({
     src,
     configAttributes: { muted, volume, ...configAttributes },
@@ -6,8 +12,9 @@ export default function applyConfigToVideoElement({
     VASTSources,
     setVolume
 }) {
-    setVolume(muted || !volume ? 0 : volume);
-    appendVideoAttributes(configAttributes, player);
+    const initialVolume = muted || !volume ? 0 : volume;
+    setVolume(initialVolume);
+    appendVideoAttributes({ ...configAttributes, volume: initialVolume }, player);
     if (isVPAID) return;
     appendVideoSources(src, player, VASTSources);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -412,13 +412,14 @@ export default class GgEzVp {
 
     // mute audio
     mute = () => {
-        this.__prevVol = this.getVolume();
+        this.__prevVol = this.getVolume() || this.config.volume || 1;
         this.volume(0);
     };
 
     // unmute audio
     unmute = () => {
-        this.volume(this.__prevVol);
+        const vol = this.__prevVol || this.config.volume || 1;
+        this.volume(vol);
     };
 
     // toggle mute
@@ -435,7 +436,7 @@ export default class GgEzVp {
         if (this.isVPAID) {
             return this.VPAIDWrapper.getAdVolume();
         }
-        return this.player.volume;
+        return this.player.muted ? 0 : this.player.volume;
     };
 
     // return the duration of the video

--- a/src/lib/controls/volume.js
+++ b/src/lib/controls/volume.js
@@ -2,7 +2,11 @@ import { VOLUME } from '../../constants';
 import createNode from '../../helpers/createNode';
 import preloadIcons from '../../helpers/preloadIcons';
 
-/* note: for initial volume, see applyConfigToVideoElement */
+/* Note: volume can only be set by the user in Safari Mobile.
+ * this.player.volume is read-only and will always return 1.
+ * https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html
+ * On other browsers, the muted configuration will take precedence over volume.
+ */
 
 const MUTE = 'mute';
 const LOW = 'low';
@@ -43,7 +47,7 @@ export default function volume(container) {
         this.volume(volumeRange.value);
     };
 
-    const initialIntensity = getVolumeIntensity(initialVolume, initialMuted);
+    const initialIntensity = getVolumeIntensity(initialMuted ? 0 : initialVolume, initialMuted);
     const iconsToLoad = intensities
         .filter(i => i !== initialIntensity)
         .map(i => {

--- a/src/lib/controls/volume.js
+++ b/src/lib/controls/volume.js
@@ -47,7 +47,7 @@ export default function volume(container) {
         this.volume(volumeRange.value);
     };
 
-    const initialIntensity = getVolumeIntensity(initialMuted ? 0 : initialVolume, initialMuted);
+    const initialIntensity = getVolumeIntensity(initialMuted ? 0 : initialVolume);
     const iconsToLoad = intensities
         .filter(i => i !== initialIntensity)
         .map(i => {
@@ -101,9 +101,9 @@ const inputAttrs = {
     step: '0.05'
 };
 
-const getVolumeIntensity = (currentVolume, muted) => {
+const getVolumeIntensity = currentVolume => {
     const volume = parseFloat(currentVolume);
-    if (muted || volume === 0) return MUTE;
+    if (volume === 0) return MUTE;
     if (volume <= 0.33) return LOW;
     if (volume > 0.33 && volume < 0.66) return MEDIUM;
     return HIGH;


### PR DESCRIPTION
This PR uses the `muted` property to set volume icons and toggle mute, instead of the volume property as we did before, this is because iOS always returns 1 from `video.volume` and the property is read-only.

Close #55.