### PR TITLE
Bugfix/vast clickthru

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,31 +210,32 @@ The default styles that can be overridden by any custom styles you may need:
 
 Use these selectors to override the styles:
 
-| selector                         | component                                                       |
-| -------------------------------- | --------------------------------------------------------------- |
-| .gg-ez-vp                        | player container                                                |
-| .gg-ez-vp--viewer                | video element                                                   |
-| .gg-ez-vp--controls              | control bar                                                     |
-| .gg-ez-vp--timestamp             | current video time                                              |
-| .gg-ez-vp--timestamp-break       | bar dividing currentime / duration                              |
-| .gg-ez-vp--timestamp-ad          | ad remaining time                                               |
-| .gg-ez-vp--volume                | volume controls container                                       |
-| .gg-ez-vp--volume-control        | volume slider container                                         |
-| .gg-ez-vp--volume-control-slider | volume slider                                                   |
-| .gg-ez-vp--input-range           | volume slider input styles                                      |
-| .gg-ez-vp--progress              | progress container                                              |
-| .gg-ez-vp--progress-bar          | progress track                                                  |
-| .gg-ez-vp--progress-filled       | progress bar fill                                               |
-| .gg-ez-vp--progress-filled:after | progress bar scrub                                              |
-| .gg-ez-vp--button-icon           | play and volume buttons                                         |
-| .gg-ez-vp--button-icon.mute      | muted state of the volume control                               |
-| .gg-ez-vp--button-icon.low       | low volume state of the volume control (under 33%)              |
-| .gg-ez-vp--button-icon.medium    | medium volume state of the volume control (between 34% and 66%) |
-| .gg-ez-vp--button-icon.high      | high volume state of the volume control (above 66%)             |
-| .gg-ez-vp--button-icon.play      | shown while video is not playing on the play control            |
-| .gg-ez-vp--button-icon.pause     | shown while video is playing on the play control                |
-| .gg-ez-vp--button-icon.replay    | shown after the video ends                                      |
-| .gg-ez-vp--button-icon.expand    | expand button icon                                              |
+| selector                         | component                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| .gg-ez-vp                        | player container                                                          |
+| .gg-ez-vp--viewer                | video element                                                             |
+| .gg-ez-vp--controls              | control bar                                                               |
+| .gg-ez-vp--timestamp             | current video time                                                        |
+| .gg-ez-vp--timestamp-break       | bar dividing currentime / duration                                        |
+| .gg-ez-vp--timestamp-ad          | ad remaining time                                                         |
+| .gg-ez-vp--volume                | volume controls container                                                 |
+| .gg-ez-vp--volume-control        | volume slider container                                                   |
+| .gg-ez-vp--volume-control-slider | volume slider                                                             |
+| .gg-ez-vp--input-range           | volume slider input styles                                                |
+| .gg-ez-vp--progress              | progress container                                                        |
+| .gg-ez-vp--progress-bar          | progress track                                                            |
+| .gg-ez-vp--progress-filled       | progress bar fill                                                         |
+| .gg-ez-vp--progress-filled:after | progress bar scrub                                                        |
+| .gg-ez-vp--button-icon           | play and volume buttons                                                   |
+| .gg-ez-vp--button-icon.mute      | muted state of the volume control                                         |
+| .gg-ez-vp--button-icon.low       | low volume state of the volume control (under 33%)                        |
+| .gg-ez-vp--button-icon.medium    | medium volume state of the volume control (between 34% and 66%)           |
+| .gg-ez-vp--button-icon.high      | high volume state of the volume control (above 66%)                       |
+| .gg-ez-vp--button-icon.play      | shown while video is not playing on the play control                      |
+| .gg-ez-vp--button-icon.pause     | shown while video is playing on the play control                          |
+| .gg-ez-vp--button-icon.replay    | shown after the video ends                                                |
+| .gg-ez-vp--button-icon.expand    | expand button icon                                                        |
+| .gg-ez-vp--blocker               | invisible div that can be used to prevent clicks on VPAID/VAST thumbnails |
 
 There are also a few modifier selectors applied to the container `.gg-ez-vp`:
 

--- a/src/helpers/loadVPAID.js
+++ b/src/helpers/loadVPAID.js
@@ -21,7 +21,7 @@ export default function loadVPAID(url, container) {
             const fn = iframe.contentWindow.getVPAIDAd;
             if (fn && typeof fn == 'function') {
                 const VPAIDCreative = fn();
-                resolve(VPAIDCreative);
+                resolve({VPAIDCreative, iframe});
             }
         };
 

--- a/src/helpers/parseVAST.js
+++ b/src/helpers/parseVAST.js
@@ -10,7 +10,6 @@ export default async function parseVAST(src, options = DEFAULT_VAST_OPTIONS) {
     const srcWithSupportedMacros = replaceVASTMacros(src);
     // Request and parse vast tag
     const parsedVAST = await vastClient.get(srcWithSupportedMacros, options);
-    console.log({ parsedVAST });
     const ad = parsedVAST?.ads[0];
     const linearCreative = ad?.creatives?.find(({ type }) => type === 'linear');
     if (!linearCreative) return;

--- a/src/helpers/parseVAST.js
+++ b/src/helpers/parseVAST.js
@@ -10,6 +10,7 @@ export default async function parseVAST(src, options = DEFAULT_VAST_OPTIONS) {
     const srcWithSupportedMacros = replaceVASTMacros(src);
     // Request and parse vast tag
     const parsedVAST = await vastClient.get(srcWithSupportedMacros, options);
+    console.log({ parsedVAST });
     const ad = parsedVAST?.ads[0];
     const linearCreative = ad?.creatives?.find(({ type }) => type === 'linear');
     if (!linearCreative) return;
@@ -23,7 +24,7 @@ export default async function parseVAST(src, options = DEFAULT_VAST_OPTIONS) {
     // Load VPAID and run it
     if (VPAIDSource) {
         this.isVPAID = true;
-        return this.__runVPAID(linearCreative, VPAIDSource);
+        return this.__runVPAID(linearCreative, VPAIDSource, vastClient, ad);
     }
 
     // if there is no VPAID, fallback to VAST tracking

--- a/src/helpers/secondsToReadableTime.js
+++ b/src/helpers/secondsToReadableTime.js
@@ -1,6 +1,7 @@
 export default function secondsToReadableTime(seconds) {
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
+    if (isNaN(mins) || isNaN(secs)) return '';
     const readableTime = `${mins}:${secs < 10 ? `0${secs}` : secs}`;
     return readableTime;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -126,11 +126,11 @@ export default class GgEzVp {
             this.container.classList.add(this.__getCSSClass());
             // listen for <video> tag resize
             this.__nodeOn(window, RESIZE, this.__playerResizeListener());
-            // set click listener on player
-            this.on('click', this.__emitPlayerClick);
             if (isVAST) {
                 return this.__runVAST();
             }
+            // set click listener on player
+            this.on('click', this.__emitPlayerClick);
             this.__renderVideoElement();
         } catch (err) {
             console.log(err); //eslint-disable-line no-console

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import isElement from './helpers/isElement';
 import parseVAST from './helpers/parseVAST';
 import secondsToReadableTime from './helpers/secondsToReadableTime';
 import hasTouchScreen from './helpers/hasTouchScreen';
+import createNode from './helpers/createNode';
 // styles
 import './styles.css';
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,10 @@ export default class GgEzVp {
         this.dataReady = false;
         this.isFullscreen = false;
         this.config = this.__getConfig(options);
+        // Create the video container
+        this.playerContainer = createNode('div', this.__getCSSClass('player-container'));
         // Create the video node
-        this.player = document.createElement('video');
+        this.player = createNode('video', this.__getCSSClass('viewer'));
         // set vast data default
         this.VASTData = null;
         this.VPAIDWrapper = null;
@@ -127,6 +129,10 @@ export default class GgEzVp {
             this.container.classList.add(this.__getCSSClass());
             // listen for <video> tag resize
             this.__nodeOn(window, RESIZE, this.__playerResizeListener());
+            // Insert the video node into its container
+            this.playerContainer.appendChild(this.player);
+            // Insert the video container into the main container
+            this.container.appendChild(this.playerContainer);
             if (isVAST) {
                 return this.__runVAST();
             }
@@ -189,6 +195,13 @@ export default class GgEzVp {
         // Execute the callback in the next cycle, using requestAnimationFrame
         // if available or setTimeout as a fallback
         nextTick(this.__setReady);
+    };
+
+    __addBlockerOverlay = () => {
+        if (this.isVPAID) {
+            const blocker = createNode('div', this.__getCSSClass('blocker'));
+            this.container.appendChild(blocker);
+        }
     };
 
     __setReady = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,10 @@ export default class GgEzVp {
         if (this.isVPAID) {
             return this.__setReadyNextTick();
         }
-        this.once('loadedmetadata', this.__setReadyNextTick);
+        this.once('loadedmetadata', () => {
+            this.emitter.emit(DATA_READY);
+            this.__setReadyNextTick();
+        });
     };
 
     __setReadyNextTick = () => {
@@ -456,7 +459,7 @@ export default class GgEzVp {
     // return the duration of the video
     getDuration = () => {
         if (this.isVPAID) {
-            return this.VPAIDWrapper.duration;
+            return this.VPAIDWrapper.getAdDuration();
         }
         const { duration } = this.player;
         return duration || 0;

--- a/src/lib/VPAIDWrapper.js
+++ b/src/lib/VPAIDWrapper.js
@@ -231,9 +231,11 @@ export default class VPAIDWrapper {
 
     // Callback for AdClickThru
     onAdClickThru(url, id, playerHandles) {
+        console.log({ url, id, playerHandles });
         this.emitter.emit('AdClickThru', { url, id, playerHandles });
         if (playerHandles) {
             this.VASTTracker.on('clickthrough', VASTClickUrl => {
+                console.log({ VASTClickUrl });
                 // use VPAID URL if available, fallback to VASTClickUrl
                 window.top.open(url || VASTClickUrl);
             });

--- a/src/lib/VPAIDWrapper.js
+++ b/src/lib/VPAIDWrapper.js
@@ -17,6 +17,7 @@ export default class VPAIDWrapper {
         if (!isValidVPAID) {
             /* eslint-disable-next-line no-console */
             console.log("GgEzVp [WARN]: The VPAIDCreative doesn't conform to the VPAID spec");
+            VASTTracker.errorWithCode(901);
             return;
         }
         this.VASTTracker = VASTTracker;
@@ -187,8 +188,6 @@ export default class VPAIDWrapper {
     onAdSizeChange() {
         const width = this._creative.getAdWidth();
         const height = this._creative.getAdHeight();
-        console.log('onAdSizeChange');
-        console.log({ width, height });
         this.emitter.emit('AdSizeChange', { width, height });
     }
 
@@ -232,13 +231,11 @@ export default class VPAIDWrapper {
 
     // Callback for AdClickThru
     onAdClickThru(url, id, playerHandles) {
-        console.log({ url, id, playerHandles });
         this.emitter.emit('AdClickThru', { url, id, playerHandles });
         if (playerHandles) {
             this.VASTTracker.on('clickthrough', VASTClickUrl => {
-                console.log({ url, VASTClickUrl });
                 // use VPAID URL if available, fallback to VASTClickUrl
-                window.open(url || VASTClickUrl);
+                window.top.open(url || VASTClickUrl);
             });
         }
         this.VASTTracker.click();

--- a/src/lib/VPAIDWrapper.js
+++ b/src/lib/VPAIDWrapper.js
@@ -97,9 +97,14 @@ export default class VPAIDWrapper {
         this._creative.setAdVolume(val);
     }
 
-    // Pass through for setAdVolume
+    // Pass through for getAdVolume
     getAdVolume() {
         return this._creative.getAdVolume();
+    }
+
+    // Pass through for getAdDuration
+    getAdDuration() {
+        return this._creative.getAdDuration();
     }
 
     // Pass through for resizeAd
@@ -231,11 +236,9 @@ export default class VPAIDWrapper {
 
     // Callback for AdClickThru
     onAdClickThru(url, id, playerHandles) {
-        console.log({ url, id, playerHandles });
         this.emitter.emit('AdClickThru', { url, id, playerHandles });
         if (playerHandles) {
             this.VASTTracker.on('clickthrough', VASTClickUrl => {
-                console.log({ VASTClickUrl });
                 // use VPAID URL if available, fallback to VASTClickUrl
                 window.top.open(url || VASTClickUrl);
             });
@@ -313,7 +316,7 @@ export default class VPAIDWrapper {
     onAdVolumeChange() {
         const volume = this._creative.getAdVolume();
         const isMuted = volume == 0;
-        this.emitter.emit('onAdVolumeChange', volume);
+        this.emitter.emit('AdVolumeChange', volume);
         this.VASTTracker.setMuted(isMuted);
     }
 }

--- a/src/lib/VPAIDWrapper.js
+++ b/src/lib/VPAIDWrapper.js
@@ -4,12 +4,13 @@ import setCallbacksForCreative from './setCallbacksForCreative';
 import { DATA_READY, ERROR, PLAYBACK_PROGRESS, VPAID_STARTED, SKIP, EXPAND } from '../constants';
 
 export default class VPAIDWrapper {
-    constructor(
+    constructor({
         VPAIDCreative,
         emitter,
-        { width: containerWidth, height: containerHeight },
-        creativeVersion
-    ) {
+        dimensions: { width: containerWidth, height: containerHeight },
+        creativeVersion,
+        VASTTracker
+    }) {
         this._creative = VPAIDCreative;
         this.emitter = emitter;
         const isValidVPAID = this.__checkVPAIDInterface(VPAIDCreative);
@@ -18,6 +19,7 @@ export default class VPAIDWrapper {
             console.log("GgEzVp [WARN]: The VPAIDCreative doesn't conform to the VPAID spec");
             return;
         }
+        this.VASTTracker = VASTTracker;
         this.__setCallbacksForCreative();
         this.emitter.on(SKIP, this.skipAd);
         this.emitter.on(EXPAND, isExpanded => {
@@ -29,6 +31,10 @@ export default class VPAIDWrapper {
             }
             this.expandAd(...expandAdArgs);
         });
+        // listen for window closing to send close events
+        window.onbeforeunload = () => {
+            VASTTracker.close();
+        };
     }
 
     __checkVPAIDInterface = checkVPAIDInterface;
@@ -126,18 +132,21 @@ export default class VPAIDWrapper {
     onAdPaused() {
         this.emitter.emit('AdPaused');
         this.emitter.emit('pause');
+        this.VASTTracker.setPaused(true);
     }
 
     // Callback for AdPlaying
     onAdPlaying() {
         this.emitter.emit('AdPlaying');
         this.emitter.emit('play');
+        this.VASTTracker.setPaused(false);
     }
 
     // Callback for AdError
     onAdError(message) {
         this.emitter.emit('AdError', message);
         this.emitter.emit(ERROR, message);
+        this.VASTTracker.errorWithCode(901);
     }
 
     // Callback for AdLog
@@ -158,6 +167,7 @@ export default class VPAIDWrapper {
     // Callback for AdUserClose
     onAdUserClose() {
         this.emitter.emit('AdUserClose');
+        this.VASTTracker.close();
     }
 
     // Callback for AdSkippableStateChange
@@ -170,12 +180,15 @@ export default class VPAIDWrapper {
     onAdExpandedChange() {
         const adExpanded = this._creative.getAdExpanded();
         this.emitter.emit('AdExpandedChange', adExpanded);
+        this.VASTTracker.setFullscreen(adExpanded);
     }
 
     // Callback for AdSizeChange
     onAdSizeChange() {
         const width = this._creative.getAdWidth();
         const height = this._creative.getAdHeight();
+        console.log('onAdSizeChange');
+        console.log({ width, height });
         this.emitter.emit('AdSizeChange', { width, height });
     }
 
@@ -184,6 +197,7 @@ export default class VPAIDWrapper {
         const duration = this._creative.getAdDuration();
         this.duration = duration;
         this.emitter.emit('AdDurationChange', duration);
+        this.VASTTracker.setDuration(duration);
     }
 
     // Callback for AdRemainingTimeChange
@@ -206,17 +220,28 @@ export default class VPAIDWrapper {
             };
             this.currentTime = currentTime;
             this.emitter.emit(PLAYBACK_PROGRESS, payload);
+            this.VASTTracker.setProgress(currentTime);
         }
     }
 
     // Callback for AdImpression
     onAdImpression() {
         this.emitter.emit('AdImpression');
+        this.VASTTracker.trackImpression();
     }
 
     // Callback for AdClickThru
     onAdClickThru(url, id, playerHandles) {
-        this.emitter.emit({ url, id, playerHandles });
+        console.log({ url, id, playerHandles });
+        this.emitter.emit('AdClickThru', { url, id, playerHandles });
+        if (playerHandles) {
+            this.VASTTracker.on('clickthrough', VASTClickUrl => {
+                console.log({ url, VASTClickUrl });
+                // use VPAID URL if available, fallback to VASTClickUrl
+                window.open(url || VASTClickUrl);
+            });
+        }
+        this.VASTTracker.click();
     }
 
     // Callback for AdInteraction
@@ -253,6 +278,7 @@ export default class VPAIDWrapper {
     onAdVideoComplete() {
         // Video 100% completed
         this.emitter.emit('AdVideoComplete');
+        this.VASTTracker.complete();
     }
 
     // Callback for AdLinearChange
@@ -281,11 +307,14 @@ export default class VPAIDWrapper {
     // Callback for skipAd
     onSkipAd() {
         this.emitter.emit('AdSkipped');
+        this.VASTTracker.skip();
     }
 
     // Callback for AdVolumeChange
     onAdVolumeChange() {
         const volume = this._creative.getAdVolume();
+        const isMuted = volume == 0;
         this.emitter.emit('onAdVolumeChange', volume);
+        this.VASTTracker.setMuted(isMuted);
     }
 }

--- a/src/lib/controls/index.js
+++ b/src/lib/controls/index.js
@@ -10,6 +10,8 @@ import play from './play';
 
 export default function renderControls() {
     const { container, config, __onTouchScreen } = this;
+    // Include a blocker div between viewer and controls
+    this.__addBlockerOverlay();
     if (!config.controls) return;
     const isAd = config.adControls;
     const controls = document.createElement('div');

--- a/src/lib/controls/timestamp.js
+++ b/src/lib/controls/timestamp.js
@@ -1,4 +1,4 @@
-import { PLAYBACK_PROGRESS, TIMESTAMP } from '../../constants';
+import { PLAYBACK_PROGRESS, TIMESTAMP, DATA_READY } from '../../constants';
 import secondsToReadableTime from '../../helpers/secondsToReadableTime';
 import createNode from '../../helpers/createNode';
 
@@ -6,7 +6,7 @@ export default function timestamp(container) {
     const currentTime = this.getCurrentTime();
     const initialDuration = this.getDuration();
     const fancyCurrentTime = secondsToReadableTime(currentTime);
-    const fancyDuration = secondsToReadableTime(initialDuration);
+    const fancyDuration = secondsToReadableTime(Math.max(initialDuration, 0));
 
     const classNameRoot = this.__getCSSClass(TIMESTAMP);
     const timestampNode = createNode('div', classNameRoot);
@@ -23,11 +23,9 @@ export default function timestamp(container) {
     });
 
     // Set duration once playback starts if it wasn't available
-    this.once('loadedmetadata', () => {
-        const duration = this.getDuration();
-        const fancyDuration = secondsToReadableTime(duration);
-        if (!initialDuration) {
-            timestampDuration.innerText = fancyDuration;
+    this.once(PLAYBACK_PROGRESS, ({ fancyDuration: updatedDuration }) => {
+        if (fancyDuration === '0:00') {
+            timestampDuration.innerText = updatedDuration;
         }
     });
 

--- a/src/lib/enableVASTTracking.js
+++ b/src/lib/enableVASTTracking.js
@@ -7,6 +7,9 @@ export default function enableVASTTracking(vastClient, ad, creative) {
     setVASTTracking(vastTracker, this.on);
     this.dataReady = true;
     this.VASTTracker = vastTracker;
+    this.VASTTracker.on('clickthrough', VASTClickUrl => {
+        window.top.open(VASTClickUrl);
+    });
     this.__attachStoredListeners();
     this.__renderVideoElement();
 }

--- a/src/lib/enableVASTTracking.js
+++ b/src/lib/enableVASTTracking.js
@@ -1,5 +1,7 @@
 import { VASTTracker } from 'vast-client';
 
+// This helper is in charge of running VAST tracking when the source IS NOT VPAID
+// When the source is VPAID, src/lib/VPAIDWrapper.js will be in charge of VAST tracking
 export default function enableVASTTracking(vastClient, ad, creative) {
     const vastTracker = new VASTTracker(vastClient, ad, creative);
     setVASTTracking(vastTracker, this.on);
@@ -20,7 +22,6 @@ function setVASTTracking(vastTracker, on) {
 // Tracking methods from:
 // https://github.com/dailymotion/vast-client-js/blob/master/docs/api/vast-tracker.md#public-methods--
 const VASTEventListeners = {
-    canplay: tracker => () => tracker.trackImpression(),
     click: tracker => () => tracker.click(),
     ended: tracker => () => tracker.complete(),
     error: tracker => () => tracker.errorWithCode(405),
@@ -30,5 +31,8 @@ const VASTEventListeners = {
     expand: tracker => isFullscreen => tracker.setFullscreen(isFullscreen),
     volumechange: tracker => e => tracker.setMuted(e.target.muted || !e.target.volume),
     timeupdate: tracker => e => tracker.setProgress(e.target.currentTime),
-    loadedmetadata: tracker => e => tracker.setDuration(e.target.duration)
+    loadedmetadata: tracker => e => {
+        tracker.trackImpression();
+        tracker.setDuration(e.target.duration);
+    }
 };

--- a/src/lib/renderVideoElement.js
+++ b/src/lib/renderVideoElement.js
@@ -3,13 +3,10 @@ import applyConfigToVideoElement from '../helpers/applyConfigToVideoElement';
 export default function renderVideoElement() {
     const {
         player,
-        container,
         isVPAID,
         VASTSources,
         config: { src, width, height, autoplay, volume, muted, poster, preload, loop, playsinline }
     } = this;
-
-    player.classList.add(this.__getCSSClass('viewer'));
 
     // Group all the video element attributes
     const configAttributes = {
@@ -33,7 +30,4 @@ export default function renderVideoElement() {
         VASTSources,
         setVolume: this.volume
     });
-
-    // Insert the video node
-    container.appendChild(player);
 }

--- a/src/lib/runVPAID.js
+++ b/src/lib/runVPAID.js
@@ -1,9 +1,11 @@
+import { VASTTracker } from 'vast-client';
 import loadVPAID from '../helpers/loadVPAID';
 import isVPAIDVersionSupported from '../helpers/isVPAIDVersionSupported';
 import VPAIDWrapper from '../lib/VPAIDWrapper';
 import { DATA_READY, SUPPORTED_VPAID_VERSION, VPAID_STARTED } from '../constants';
 
-export default async function runVPAID(creative, VPAIDSource) {
+export default async function runVPAID(creative, VPAIDSource, vastClient, ad) {
+    const vastTracker = new VASTTracker(vastClient, ad, creative);
     const { adParameters } = creative;
     const VPAIDCreative = await loadVPAID(VPAIDSource.fileURL, this.container);
     const VPAIDCreativeVersion = VPAIDCreative.handshakeVersion(SUPPORTED_VPAID_VERSION);
@@ -11,12 +13,13 @@ export default async function runVPAID(creative, VPAIDSource) {
     const { offsetWidth: width, offsetHeight: height } = this.container;
     const originalDimensions = { width, height };
     if (canSupportVPAID) {
-        this.VPAIDWrapper = new VPAIDWrapper(
+        this.VPAIDWrapper = new VPAIDWrapper({
             VPAIDCreative,
-            this.emitter,
-            originalDimensions,
-            VPAIDCreativeVersion
-        );
+            emitter: this.emitter,
+            dimensions: originalDimensions,
+            creativeVersion: VPAIDCreativeVersion,
+            VASTTracker: vastTracker
+        });
         this.once(DATA_READY, () => {
             this.dataReady = true;
             this.__attachStoredListeners();

--- a/src/lib/runVPAID.js
+++ b/src/lib/runVPAID.js
@@ -28,6 +28,9 @@ export default async function runVPAID(creative, VPAIDSource, vastClient, ad) {
             this.__configureVPAID();
             this.__setReadyNextTick();
         });
+        this.once('AdSizeChange', dimensions => {
+            this.dimensions = dimensions;
+        });
         this.once(VPAID_STARTED, () => {
             this.VPAIDStarted = true;
         });

--- a/src/lib/runVPAID.js
+++ b/src/lib/runVPAID.js
@@ -7,10 +7,14 @@ import { DATA_READY, SUPPORTED_VPAID_VERSION, VPAID_STARTED } from '../constants
 export default async function runVPAID(creative, VPAIDSource, vastClient, ad) {
     const vastTracker = new VASTTracker(vastClient, ad, creative);
     const { adParameters } = creative;
-    const VPAIDCreative = await loadVPAID(VPAIDSource.fileURL, this.container);
+    const VPAIDCreative = await loadVPAID(VPAIDSource.fileURL, this.playerContainer);
     const VPAIDCreativeVersion = VPAIDCreative.handshakeVersion(SUPPORTED_VPAID_VERSION);
     const canSupportVPAID = isVPAIDVersionSupported(VPAIDCreativeVersion);
-    const { offsetWidth: width, offsetHeight: height } = this.container;
+    const { offsetWidth: width, offsetHeight: height } = this.playerContainer;
+    //TODO: CONTINUE HERE
+    // TODO: VPAID IFRAME WIDTH IS LESS THAN THE CONTAINER WHEN NOT VISIBLE
+    console.log(this.playerContainer);
+    console.log({ width, height });
     const originalDimensions = { width, height };
     if (canSupportVPAID) {
         this.VPAIDWrapper = new VPAIDWrapper({
@@ -30,6 +34,7 @@ export default async function runVPAID(creative, VPAIDSource, vastClient, ad) {
             this.VPAIDStarted = true;
         });
         this.__mountVideoElement();
+        this.__renderControls();
         this.__initVPAIDAd({ adParameters });
     }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,8 @@
     font-size: 11px;
     color: #ffffff;
     font-weight: lighter;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+        'Open Sans', 'Helvetica Neue', sans-serif;
     overflow: hidden;
 }
 
@@ -24,7 +25,6 @@
     width: 100%;
 }
 
-
 .gg-ez-vp--top,
 .gg-ez-vp--middle,
 .gg-ez-vp--bottom {
@@ -40,8 +40,6 @@
 .gg-ez-vp--bottom {
     height: 30px;
 }
-
-
 
 .gg-ez-vp--item-left,
 .gg-ez-vp--item-right {
@@ -70,17 +68,16 @@
     flex-direction: column;
     justify-content: flex-end;
     transform: translateY(100%) translateY(-39px);
-    transition: all .3s;
+    transition: all 0.3s;
     background: transparent;
 }
-
 
 .gg-ez-vp--timestamp {
     display: flex;
     flex-direction: row;
     font-weight: normal;
     margin: 6px;
-    opacity: .8;
+    opacity: 0.8;
     user-select: none;
 }
 
@@ -90,7 +87,7 @@
 
 .gg-ez-vp--timestamp-ad {
     margin: 6px;
-    opacity: .5;
+    opacity: 0.5;
     user-select: none;
     -webkit-user-select: none;
     -khtml-user-select: none;
@@ -102,7 +99,6 @@
 .gg-ez-vp:hover .gg-ez-vp--timestamp-ad {
     opacity: 1;
 }
-
 
 .gg-ez-vp--button-skip {
     display: none;
@@ -117,15 +113,14 @@
     background: #1f1f1f;
     border: 1px solid #bababa;
     cursor: pointer;
-    opacity: .5;
-    transition: all .3s;
+    opacity: 0.5;
+    transition: all 0.3s;
 }
 
 .gg-ez-vp--touchscreen .gg-ez-vp--button-skip,
 .gg-ez-vp--button-skip:hover {
     opacity: 1;
 }
-
 
 .gg-ez-vp--button-icon {
     background: none;
@@ -136,14 +131,13 @@
     outline: 0;
     padding: 0;
     cursor: pointer;
-    opacity: .7;
+    opacity: 0.7;
 }
 
 .gg-ez-vp--touchscreen .gg-ez-vp--button-icon,
 .gg-ez-vp--button-icon:hover {
     opacity: 1;
 }
-
 
 .gg-ez-vp--button-icon.mute {
     background-image: url(./icons/mute.svg);
@@ -172,7 +166,6 @@
     width: 19px;
     margin: 6px;
 }
-
 
 .gg-ez-vp--button-icon.play {
     background-image: url(./icons/play.svg);
@@ -210,10 +203,10 @@
 
 .gg-ez-vp--volume-control {
     opacity: 0;
-    transition: all .3s ease-in-out;
+    transition: all 0.3s ease-in-out;
 }
 
-.gg-ez-vp--touchscreen  .gg-ez-vp--volume-control,
+.gg-ez-vp--touchscreen .gg-ez-vp--volume-control,
 .gg-ez-vp--volume:hover > .gg-ez-vp--volume-control,
 .gg-ez-vp--volume:hover > .gg-ez-vp--button-icon {
     opacity: 1;
@@ -222,7 +215,6 @@
 .gg-ez-vp--progress {
     width: 100%;
 }
-
 
 .gg-ez-vp--progress-bar {
     position: relative;
@@ -237,20 +229,20 @@
 .gg-ez-vp--progress-filled {
     position: relative;
     width: 0%;
-    background: #FFCE00;
+    background: #ffce00;
     flex: 0;
     flex-basis: 0%;
 }
 
 .gg-ez-vp--progress-filled::after {
-    content: " ";
+    content: ' ';
     position: absolute;
     right: -6px;
     top: -3px;
     width: 9px;
     height: 9px;
     border-radius: 10px;
-    background: #FFCE00;
+    background: #ffce00;
     z-index: 100;
     opacity: 0;
     -webkit-box-shadow: 0px 0px 41px -12px rgba(0, 0, 0, 0.6);
@@ -261,7 +253,6 @@
 div.gg-ez-vp--progress-filled:hover::after {
     opacity: 1;
 }
-
 
 .gg-ez-vp--input-range {
     -webkit-appearance: none;
@@ -328,16 +319,13 @@ div.gg-ez-vp--progress-filled:hover::after {
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 100%);
 }
 
-
 .gg-ez-vp:hover .gg-ez-vp--progress-bar {
     margin: 0 6px;
 }
 
-
 .gg-ez-vp .gg-ez-vp--top > .gg-ez-vp--item-left {
     display: none;
 }
-
 
 /* Show Ad Unit Countdown Timestamp & Volume  */
 /* Example: <div class="gg-ez-vp  gg-ez-vp--ad"> */
@@ -349,7 +337,6 @@ div.gg-ez-vp--progress-filled:hover::after {
     display: none;
 }
 
-
 /* Allow Skip */
 /* Add .gg-ez-vp--skip to show SKIP button */
 /* Example: <div class="gg-ez-vp  gg-ez-vp--skip"> */
@@ -357,7 +344,6 @@ div.gg-ez-vp--progress-filled:hover::after {
 .gg-ez-vp--skip .gg-ez-vp--button-skip {
     display: inline-block;
 }
-
 
 /* Ad Video w/ Ad Countdown & Volume - no scrub & no play pause */
 /* Add class gg-ez-vp--no-scrub */
@@ -389,8 +375,6 @@ div.gg-ez-vp--progress-filled:hover::after {
     display: none;
 }
 
-
-
 /* Video Volume Only w/ extra padding  */
 /* Add class gg-ez-vp--volume-only */
 /* Example: <div class="gg-ez-vp  gg-ez-vp--volume-only"> */
@@ -402,7 +386,7 @@ div.gg-ez-vp--progress-filled:hover::after {
     width: 30px;
     height: auto;
     transform: translateY(0);
-    transition: all .3s;
+    transition: all 0.3s;
 }
 
 .gg-ez-vp.gg-ez-vp--volume-only .gg-ez-vp--bottom,
@@ -436,7 +420,7 @@ div.gg-ez-vp--progress-filled:hover::after {
 }
 
 /* Portrait */
-@media screen and (orientation:portrait) {
+@media screen and (orientation: portrait) {
     .gg-ez-vp.gg-ez-vp--touchscreen:fullscreen .gg-ez-vp--viewer {
         margin: 50% auto;
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -58,6 +58,7 @@
 }
 
 .gg-ez-vp--controls {
+    z-index: 9999;
     position: absolute;
     left: 0;
     right: 0;
@@ -428,4 +429,13 @@ div.gg-ez-vp--progress-filled:hover::after {
     .gg-ez-vp.gg-ez-vp--touchscreen:-webkit-full-screen .gg-ez-vp--viewer {
         margin: 50% auto;
     }
+}
+
+.gg-ez-vp--blocker {
+    display: none;
+    position: absolute;
+    z-index: 9998;
+    width: 100%;
+    height: 100%;
+    top: 0;
 }


### PR DESCRIPTION
This PR will fix the issues with VAST and VPAID clickthru, as this functionality was not implemented. Likewise, VAST tracking was not implemented when running VPAID, but it is now implemented inside the VPAIDWrapper.

Additionally some UI fixes were included when running VPAID in the timestamp and volume controls.

A new element called `gg-ez-vp--blocker` was included to help users prevent clicks on VAST thumbnails if necessary, for example on thumbnails.