### PR TITLE
Bugfix/inconsistent VAST loading

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,12 +1,22 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width">
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width" />
         <title>GgEzVp Demo page</title>
-        <link rel="stylesheet" href="https://ds.gumgum.com/stable/theme-blue.css" type="text/css" media="all">
-        <link rel="stylesheet" href="https://c.gumgum.com/vp/latest/gg-ez-vp.css" type="text/css" media="all">
-        <link rel="stylesheet" href="styles.css" type="text/css" media="all">
+        <link
+            rel="stylesheet"
+            href="https://ds.gumgum.com/stable/theme-blue.css"
+            type="text/css"
+            media="all"
+        />
+        <link
+            rel="stylesheet"
+            href="https://c.gumgum.com/vp/latest/gg-ez-vp.css"
+            type="text/css"
+            media="all"
+        />
+        <link rel="stylesheet" href="styles.css" type="text/css" media="all" />
     </head>
     <body>
         <h1 class="gds-text--header-md -text-center -m-v-2">
@@ -15,32 +25,107 @@
         <div class="gds-layout__container">
             <div class="gds-layout__row">
                 <div class="gds-layout__column--sm-12 gds-layout__column--md-12">
-                     <div id="videoContainer1" class="video-containers -text-center"></div>
-                     <div class="gds-button-group">
-                        <button id="play-btn" type="button" class="gds-button-group__button gds-button--primary">Toggle playback</button>
-                        <button id="mute-btn" type="button" class="gds-button-group__button gds-button--warning">Toggle mute</button>
-                        <button id="destroy-btn" type="button" class="gds-button-group__button gds-button--danger">Destroy instance</button>
-                        <button id="reload-btn" type="button" class="gds-button-group__button gds-button--default">Recreate instance</button>
-                     </div>
-
+                    <div class="gds-card -p-a-2">
+                        <div id="videoContainer1" class="video-containers -text-center"></div>
+                        <div class="gds-form-group -m-b-1" data-gds-form-group="">
+                            <label class="gds-form-group__label" for="input-0">Source URL</label>
+                            <input
+                                class="gds-form-group__text-input"
+                                type="text"
+                                id="input-0"
+                                placeholder="Enter a VAST or media file URL"
+                                data-gds-input=""
+                            />
+                        </div>
+                        <div class="gds-form-group__toggleswitch -m-v-1">
+                            <label class="gds-form-group__toggleswitch-label">
+                                <input
+                                    class="gds-form-group__toggleswitch-input"
+                                    type="checkbox"
+                                    value=""
+                                    data-gds-input=""
+                                />
+                                <span class="gds-form-group__toggleswitch-indicator"></span>VAST
+                            </label>
+                        </div>
+                        <div class="gds-button-group gds-button-group--responsive">
+                            <button
+                                type="button"
+                                class="play-btn gds-button-group__button gds-button--primary"
+                            >
+                                Toggle playback
+                            </button>
+                            <button
+                                type="button"
+                                class="mute-btn gds-button-group__button gds-button--warning"
+                            >
+                                Toggle mute
+                            </button>
+                            <button
+                                type="button"
+                                class="reload-btn gds-button-group__button gds-button--default"
+                            >
+                                Recreate instance
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="gds-layout__row">
                 <div class="gds-layout__column--sm-12 gds-layout__column--md-12">
-                     <div id="videoContainer2" class="video-containers -text-center"></div>
-                     <div class="gds-button-group"> 
-                        <button id="play-btn1" type="button" class="gds-button-group__button gds-button--primary">Toggle playback</button>
-                        <button id="mute-btn1" type="button" class="gds-button-group__button gds-button--warning">Toggle mute</button>
-                        <button id="destroy-btn1" type="button" class="gds-button-group__button gds-button--danger">Destroy instance</button>
-                        <button id="reload-btn1" type="button" class="gds-button-group__button gds-button--default">Recreate instance</button>
-                     </div>
-
+                    <div class="gds-card -p-a-2">
+                        <div id="videoContainer2" class="video-containers -text-center"></div>
+                        <div class="gds-form-group -m-b-1" data-gds-form-group="">
+                            <label class="gds-form-group__label" for="input-1">Source URL</label>
+                            <input
+                                class="gds-form-group__text-input"
+                                type="text"
+                                id="input-1"
+                                placeholder="Enter a VAST or media file URL"
+                                data-gds-input=""
+                            />
+                        </div>
+                        <div class="gds-form-group__toggleswitch -m-v-1">
+                            <label class="gds-form-group__toggleswitch-label">
+                                <input
+                                    class="gds-form-group__toggleswitch-input"
+                                    type="checkbox"
+                                    value=""
+                                    data-gds-input=""
+                                />
+                                <span class="gds-form-group__toggleswitch-indicator"></span>VAST
+                            </label>
+                        </div>
+                        <div class="gds-button-group gds-button-group--responsive">
+                            <button
+                                type="button"
+                                class="play-btn gds-button-group__button gds-button--primary"
+                            >
+                                Toggle playback
+                            </button>
+                            <button
+                                type="button"
+                                class="mute-btn gds-button-group__button gds-button--warning"
+                            >
+                                Toggle mute
+                            </button>
+                            <button
+                                type="button"
+                                class="reload-btn gds-button-group__button gds-button--default"
+                            >
+                                Recreate instance
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
 
-        <script src="https://c.gumgum.com/vp/latest/gg-ez-vp.js" async ></script>
-        <!-- local URL <script src="dist/gg-ez-vp.js" async ></script> -->
-        <script src="demo.js" async ></script>
+        <!-- prod URL  -->
+        <script src="https://c.gumgum.com/vp/latest/gg-ez-vp.js" async></script>
+        <!-- local URL
+            <script src="dist/gg-ez-vp.js" async></script>
+        -->
+        <script src="demo.js" async></script>
     </body>
 </html>

--- a/demo.js
+++ b/demo.js
@@ -1,72 +1,74 @@
 /*global GgEzVp*/
-
-window.onload = function onload() {
-    console.log({ GgEzVp });
-
-    // MP4 test
-    let playerInstance = new GgEzVp({
+const configs = [
+    //MP4
+    {
         container: 'videoContainer1',
-        src: 'https://aba.gumgum.com/13861/8/big_buck_bunny_640x360.mp4',
-        autoplay: false,
-        volume: '0.5'
-    });
-
-    // Set listeners
-    playerInstance.on('ready', () => {
-        playerInstance.on('play', console.log);
-        playerInstance.on('pause', console.log);
-        playerInstance.on('timeupdate', console.log);
-        playerInstance.on('predestroy', () => {
-            console.log('DESTROYING FIRST CONTAINER');
-            playerInstance = null;
-        });
-    });
-    playerInstance.on('error', console.log);
-
-    // VAST test
-    let playerInstance1 = new GgEzVp({
+        src: 'https://aba.gumgum.com/13861/8/big_buck_bunny_640x360.mp4'
+    },
+    // VAST
+    {
         container: 'videoContainer2',
         src:
             'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=[timestamp]',
-        autoplay: false,
         isVAST: true
-    });
+    }
+];
+const events = [
+    'data-ready',
+    'playback-progress',
+    'player-click',
+    'pre-destroy',
+    ['ready', instance => instance.play()],
+    'resize',
+    'error',
+    'VPAID-started'
+];
 
-    // Set listeners
-    //playerInstance1.on('ready', () => {
-    //    playerInstance1.on('play', console.log);
-    //    playerInstance1.on('pause', console.log);
-    //    playerInstance1.on('timeupdate', console.log);
-    //    playerInstance1.on('predestroy', () => {
-    //        console.log('DESTROYING SECOND CONTAINER');
-    //        playerInstance1 = null;
-    //    });
-    //});
-    //playerInstance1.on('error', console.log);
-
-    // Configure instance 1 buttons
-    const playBtn = document.getElementById('play-btn');
-    playBtn.addEventListener('click', () => playerInstance.playPause());
-
-    const muteBtn = document.getElementById('mute-btn');
-    muteBtn.addEventListener('click', () => playerInstance.muteUnmute());
-
-    const rmBtn = document.getElementById('destroy-btn');
-    rmBtn.addEventListener('click', () => playerInstance.destroy());
-
-    const f5Btn = document.getElementById('reload-btn');
-    f5Btn.addEventListener('click', () => location.reload());
-
-    // Configure instance 2 buttons
-    const playBtn1 = document.getElementById('play-btn1');
-    playBtn1.addEventListener('click', () => playerInstance1.playPause());
-
-    const muteBtn1 = document.getElementById('mute-btn1');
-    muteBtn1.addEventListener('click', () => playerInstance1.muteUnmute());
-
-    const rmBtn1 = document.getElementById('destroy-btn1');
-    rmBtn1.addEventListener('click', () => playerInstance1.destroy());
-
-    const f5Btn1 = document.getElementById('reload-btn1');
-    f5Btn1.addEventListener('click', () => location.reload());
+window.onload = function onload() {
+    configs.forEach(createPlayerInstance);
 };
+
+function createPlayerInstance(config) {
+    const instance = new GgEzVp(config);
+    const logger = (eventName, cb) => {
+        return evt => {
+            // eslint-disable-next-line
+            console.log(`${eventName} - Instance ${config.container} log:`, evt);
+            if (cb) cb(instance);
+        };
+    };
+    // Set player listeners
+    events.forEach(event => {
+        const [eventName, cb] = Array.isArray(event) ? event : [event];
+        instance.on(eventName, logger(eventName, cb));
+    });
+    // Set instance demo controls
+    setDemoControls(instance, config);
+    return instance;
+}
+
+const nextTick = requestAnimationFrame || setTimeout;
+
+function setDemoControls(playerInstance, config) {
+    const sectionContainer = playerInstance.container.parentNode;
+    const playBtn = sectionContainer.querySelector('.play-btn');
+    const muteBtn = sectionContainer.querySelector('.mute-btn');
+    const input = sectionContainer.querySelector('.gds-form-group__text-input');
+    const f5Btn = sectionContainer.querySelector('.reload-btn');
+    const checkbox = sectionContainer.querySelector('.gds-form-group__toggleswitch-input');
+
+    if (!input.value) input.value = config.src;
+    if (config.isVAST) checkbox.checked = true;
+
+    playerInstance.__nodeOn(playBtn, 'click', () => playerInstance.playPause());
+    playerInstance.__nodeOn(muteBtn, 'click', () => playerInstance.muteUnmute());
+    playerInstance.__nodeOn(f5Btn, 'click', () => {
+        playerInstance.destroy();
+        playerInstance = null;
+        nextTick(() => {
+            const src = input.value || config.src;
+            const isVAST = !!checkbox.checked;
+            playerInstance = createPlayerInstance({ ...config, src, isVAST });
+        });
+    });
+}

--- a/src/helpers/loadVPAID.js
+++ b/src/helpers/loadVPAID.js
@@ -21,7 +21,7 @@ export default function loadVPAID(url, container) {
             const fn = iframe.contentWindow.getVPAIDAd;
             if (fn && typeof fn == 'function') {
                 const VPAIDCreative = fn();
-                resolve({VPAIDCreative, iframe});
+                resolve({ VPAIDCreative, iframe });
             }
         };
 

--- a/src/helpers/replaceVASTMacros.js
+++ b/src/helpers/replaceVASTMacros.js
@@ -2,15 +2,17 @@
 // https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_apiframeworks
 const MACROS_DICT = {
     '[APIFRAMEWORKS]': 2, //VPAID 2.0
-    '[SERVERSIDE]': 0 // false, requesting from client
+    '[SERVERSIDE]': 0, // false, requesting from client
+    '[TIMESTAMP]': () => Date.now() // false, requesting from client
     //'[OMIDPARTNER]': 0 // TODO
 };
 
 export default function replaceVASTMacros(src) {
     let tmpSrc = src;
     Object.keys(MACROS_DICT).forEach(macro => {
-        const value = MACROS_DICT[macro];
-        tmpSrc = src.replace(macro, value);
+        const valueContainer = MACROS_DICT[macro];
+        const value = typeof valueContainer === 'function' ? valueContainer() : valueContainer;
+        tmpSrc = src.replace(macro, value).replace(macro.toLowerCase(), value);
     });
     return tmpSrc;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -112,10 +112,7 @@ export default class GgEzVp {
         const ggEzVpScripts = [].slice
             .call(document.getElementsByTagName('script'))
             .filter(a => a.src.includes(JS_FILENAME));
-        if (ggEzVpScripts.length > 1) {
-            throw Error(`GgEzVp [Error]: loading more than one ${JS_FILENAME}`);
-        }
-        return ggEzVpScripts[0].src.replace(JS_FILENAME, '');
+        return ggEzVpScripts[ggEzVpScripts.length - 1].src.replace(JS_FILENAME, '');
     };
 
     // set up controls and internal listeners

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,9 @@ export default class GgEzVp {
     };
 
     // find the base URL that the file was loaded from
-    // only one URL ending in '/gg-ez-vp.js' is allowed
+    // only the last URL ending in '/gg-ez-vp.js' is allowed
+    // Base URL is used to preload icons
+    // TODO: find a better way to preload them, maybe include them in build (#63)
     __getBaseURL = () => {
         const ggEzVpScripts = [].slice
             .call(document.getElementsByTagName('script'))


### PR DESCRIPTION
This PR fixes VAST/VPAID inconsistent loading. I think this happened because we didn't replace the `[timestamp]` macro from the VAST URLs, and ad servers don't seem to like this.

After replacing the macro, this issue seems to be gone.

Additionally, for easier debugging, I improved the demo page so that sources can be changed dynamically now.

The player will now get the BaseURL from the last gg-ez-vp.js script it finds instead of throwing an error when there is more than one script, but this is just a temporary fix while #63 is fixed.