### PR TITLE
Handle VPAID replay (#58)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ export default class GgEzVp {
         // set vast data default
         this.VASTData = null;
         this.VPAIDWrapper = null;
+        this.controlsRendered = false;
         this.__onTouchScreen = hasTouchScreen();
         // find the base url that the file was loaded from
         this.__baseURL = this.__getBaseURL();
@@ -440,6 +441,10 @@ export default class GgEzVp {
 
     // toggle media playback
     playPause = () => {
+        if (this.isVPAID && this.VPAIDFinished) {
+            // REPLAYING VAST
+            return this.__runVAST();
+        }
         if (this.player.paused) {
             return this.play();
         }
@@ -488,17 +493,28 @@ export default class GgEzVp {
 
     // return the duration of the video
     getDuration = () => {
+        let duration;
         if (this.isVPAID) {
-            return this.VPAIDWrapper.getAdDuration();
+            if (this.VPAIDFinished) {
+                // Use last known duration
+                duration = this.duration;
+            } else {
+                // Retrieve duration from VPAID wrapper
+                duration = this.VPAIDWrapper.getAdDuration();
+            }
+        } else {
+            // Get video tag duration
+            duration = this.player.duration;
         }
-        const { duration } = this.player;
+        // store duration
+        this.duration = duration;
         return duration || 0;
     };
 
     // return the currentTime of the video
     getCurrentTime = () => {
         if (this.isVPAID) {
-            return this.VPAIDWrapper.currentTime;
+            return this.VPAIDFinished ? this.duration : this.VPAIDWrapper.currentTime;
         }
         const { currentTime } = this.player;
         return currentTime;

--- a/src/lib/controls/index.js
+++ b/src/lib/controls/index.js
@@ -9,7 +9,9 @@ import timestamp from './timestamp';
 import play from './play';
 
 export default function renderControls() {
-    const { container, config, __onTouchScreen } = this;
+    const { container, config, __onTouchScreen, controlsRendered } = this;
+    // Cancel if controls are already rendered
+    if (controlsRendered) return;
     // Include a blocker div between viewer and controls
     this.__addBlockerOverlay();
     if (!config.controls) return;
@@ -20,6 +22,8 @@ export default function renderControls() {
     controls.classList.add(this.__getCSSClass('controls'));
     nodeRenderer.call(this, config, sections, controls);
     container.appendChild(controls);
+    // Set flag for successful controls rendering
+    this.controlsRendered = true;
 }
 
 function nodeRenderer(config, sections, container) {

--- a/src/lib/runVPAID.js
+++ b/src/lib/runVPAID.js
@@ -33,11 +33,22 @@ export default async function runVPAID(creative, VPAIDSource, vastClient, ad) {
         });
         this.once(VPAID_STARTED, () => {
             this.VPAIDStarted = true;
+            this.VPAIDFinished = false;
+        });
+        this.once('AdVideoComplete', () => {
+            // Reset all flags
+            this.VPAIDStarted = false;
+            this.VPAIDFinished = true;
+            this.dataReady = false;
+            this.VPAIDWrapper = null;
+            this.VASTData = null;
         });
         // Add a resize listener for the VPAID iframe (GH-48)
         this.__nodeOn(this.VPAIDiframe.contentWindow, RESIZE, () => {
             const { innerHeight: height, innerWidth: width } = this.VPAIDiframe.contentWindow;
-            this.VPAIDWrapper.resizeAd(width, height, 'normal');
+            if (!this.VPAIDFinished) {
+                this.VPAIDWrapper.resizeAd(width, height, 'normal');
+            }
         });
         this.__mountVideoElement();
         this.__renderControls();


### PR DESCRIPTION
This PR will handle replaying VPAID ads by reloading the VAST flow when the user calls the `playPause` method after VPAID has finished and cleaned up after itself.

This will render the controls just once.

This closes #58.