### PR TITLE
Check for window.frameElement before changing attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export default class GgEzVp {
     __allowIframeFullscreen = () => {
         // This will allow fullscreen in firefox when inside iframes
         // https://stackoverflow.com/a/9747340/1335287
-        if (inIframe()) {
+        if (window.frameElement && inIframe()) {
             window.frameElement.setAttribute('allow', 'fullscreen');
         }
     };


### PR DESCRIPTION
window.frameElement is only available in a friendly iframe (origin of iframe url and parent page are the same)

in an unfriendly iframe an error is thrown, because window.frameElement isn't available.

That's why this check is needed.