### PR TITLE
eneble git releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dist
 package-lock.json
 dist/
 dist
+.idea
 
 # Vim specific
 .vim

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "dist/gg-ez-vp.cjs.js",
   "module": "dist/gg-ez-vp.esm.js",
   "browser": "dist/gg-ez-vp.js",
-  "files": [
-    "dist"
-  ],
   "repository": "git@github.com:gumgum/gg-ez-vp.git",
   "bugs": "https://github.com/gumgum/gg-ez-vp/issues",
   "license": "MIT",
@@ -44,6 +41,7 @@
     "start": "run-p build:dev devServer",
     "prebuild": "yarn run clean",
     "build": "rollup -c",
+    "prepare": "rollup -c",
     "build:dev": "rollup -c -w",
     "devServer": "http-server "
   },


### PR DESCRIPTION
Currently do not release npm packages anymore:
https://www.npmjs.com/package/gg-ez-vp -> `1.9.0 • Public • Published a year ago`

And also when you try to download it by git releases final package is broken because it does not contain a `dist` files (it do not do prebuild) -> `node_modules/gg-ez-vp` contain only: 

```
CHANGELOG.md
LICENSE
package.json
README.md
```

This PR enables using your package via git release: `"gg-ez-vp": "git://github.com/gumgum/gg-ez-vp.git",`
